### PR TITLE
[CI] sample_archive を使った smoke test workflow を追加

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -1,0 +1,48 @@
+name: Smoke Test
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  smoke-test:
+    runs-on: ubuntu-latest
+
+    env:
+      PYTHONUTF8: "1"
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Run smoke test
+        run: |
+          python competitor_analytics_generator.py --lecture-ids "01,02" --archive-dir "sample_archive"
+
+      - name: Verify outputs
+        run: |
+          test -d reports/competitor_analytics
+          test -d reports/html
+          test -d reports/text
+          find reports/competitor_analytics -type f | grep "\.json$"
+          find reports/html -type f | grep "\.html$"
+          find reports/text -type f | grep "\.txt$"
+
+      - name: Upload generated reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: smoke-test-reports
+          path: reports/


### PR DESCRIPTION
## 概要
sample_archive を使った最小実行 smoke test を GitHub Actions に追加しました。

## 背景
README / sample_archive / requirements の整備により最小実行導線は改善されたため、
次にその動作を PR ごとに自動確認できるようにしたいです。

## 対応内容
- `.github/workflows/smoke-test.yml` を追加
- PR / main push 時に workflow 実行
- `competitor_analytics_generator.py --lecture-ids "01,02" --archive-dir "sample_archive"` を実行
- reports 配下の JSON / HTML / Text 出力を確認
- 生成物を artifact としてアップロード

## 確認事項
- `.env` や API キーなしで最小実行できることを前提にしている
- コアロジックは変更していない
- smoke test は sample_archive ベースの最小確認に限定している

## レビューポイント
- workflow の粒度は適切か
- 出力確認条件は妥当か
- artifact 保存は必要十分か
