### PR TITLE
[Docs] app.py ベースの実装実態に合わせて README / docs を同期

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,97 +5,89 @@ YouTube 動画の洞察・競合分析システム。動画視聴データを構
 ---
 
 ## 1. プロジェクト概要
-YouTube動画から抽出されたメタデータや知識構造（json）を入力とし、ポートフォリオビュー、成長推移ビュー、テーマ別ビューなどの分析結果をJSON/HTML/Text形式で自動生成します。
+本プロジェクトは、YouTube動画から抽出されたメタデータや知識構造（JSON形式の `insight_spec`）を入力とし、各種分析ビュー（ポートフォリオビュー、成長推移ビュー、テーマ別ビュー）を生成して、人間が読みやすい形式（HTML/Text）のレポートとして自動出力するシステムです。
 
-## 2. できること / まだできないこと
-- **できること（実装済）**: 
-  - 事前に処理された JSON データ（insight_spec）からの各種分析ビュー生成
-  - HTML（ブラウザ向け）/ テキスト（マークダウン互換）形式でのレポート生成
-  - ※ 経営者向け1ページサマリー（Executive Summary）のフォーマッタは存在しますが、現在の主実行経路（competitor_analytics_generator.py）には未統合です。
-- **まだできないこと（将来予定）**: 
-  - Webダッシュボードでのリアルタイム可視化
-  - REST APIによるデータ公開
-  - Slack等への自動通知・アラート
-  - AIによる自動提案生成（Phase 8以降）
+## 2. 実装済みのこと / 未実装のこと
+コードの解析結果に基づき、現在の実装状況は以下の通りとなっています。
 
-## 3. 最小実行に必要なもの
-「最小実行」とは、本リポジトリに付属している「処理済みダミーデータ」を用いて、レポート生成スクリプト（`competitor_analytics_generator.py`）を単独で動かすことを指します。
+- **実装済みのこと**:
+  - 事前に処理された JSON データ（`insight_spec`）からの各種分析ビュー（Portfolio / Growth / Theme View）の生成ロジック。
+  - HTML（レスポンシブデザイン対応）および テキスト（Markdown互換）形式での競合分析レポート自動生成。
+  - 最小実行用のサンプルデータ（`sample_archive/` 配下に同梱）。
+- **未実装のこと（将来計画 / フェーズ7以降）**:
+  - **Webダッシュボード機能 (`app.py` 等)**: 現在、リポジトリ内に `app.py` や Streamlit/Flask 等を用いたダッシュボード用の実装コード・起動スクリプトは**存在しません**（ビジョン・計画段階です）。
+  - **REST API / Slack統合**: APIによるデータ公開機能やSlack自動通知機能は未実装です。
+  - **AIによる自動提案生成**: フェーズ8以降での実装計画となっています。
 
-- Python 3.8+
-- 処理済みの JSON データを含むディレクトリ（本リポジトリに同梱されている `sample_archive/` を使用できます）
-- ※ **注意**: 最小実行においては、環境変数 `.env`（および `YOUTUBE_API_KEY`）は**不要**です。スクリプトは既存のJSONファイルを読み込むだけで完結します。
+## 3. 起動方法の全体像
+本リポジトリにおける主要な実行経路の全体像です。
 
-## 4. 最小実行手順
-1. **リポジトリをクローン**
-   ```bash
-   git clone <repository-url>
-   cd video-insight-spec
-   ```
-2. **依存関係のインストール**
+| 実行モード | エントリポイント | 必要データ | 必要な環境変数/`.env` | 現状のステータス |
+| :--- | :--- | :--- | :--- | :--- |
+| **バッチレポート生成** | `competitor_analytics_generator.py` | `insight_spec_*.json` | **不要** (最小実行時) | **実装済み・即時実行可能** |
+| **Webダッシュボード** | `app.py` (※未存在) | - | - | **未実装 (将来予定)** |
+
+> [!IMPORTANT]
+> リポジトリ内には現在 `app.py` は存在せず、Webダッシュボードを起動する手段はありません。現行バージョンでの主要な使い方は、`competitor_analytics_generator.py` を用いた「バッチレポート生成」となります。
+
+## 4. 最小実行
+「最小実行」とは、本リポジトリに付属している「処理済みダミーデータ」を用いて、レポート生成スクリプトを単独で動かすことを指します。このモードでは環境変数 `.env`（および `YOUTUBE_API_KEY`）は**不要**です。
+
+### 最小実行手順:
+1. **依存関係のインストール**:
    ```bash
    pip install -r requirements.txt
    ```
-3. **サンプルデータでの実行**
-   同梱されているダミーデータを使ってレポートを生成します。
+2. **サンプルデータでの実行**:
    ```bash
    python competitor_analytics_generator.py --lecture-ids "01,02" --archive-dir "sample_archive"
    ```
-   ※ Windows 環境で絵文字による `UnicodeEncodeError` 等の文字化けが出る場合は、UTF-8 モードで実行してください。
+   ※ Windows環境で絵文字等の文字化けや `UnicodeEncodeError` が発生する場合は、以下のように UTF-8 モードを有効にして実行してください。
    ```powershell
    $env:PYTHONUTF8=1; python competitor_analytics_generator.py --lecture-ids "01,02" --archive-dir "sample_archive"
    ```
 
-## 5. YouTube API を使う処理を行う場合の追加前提
-新規のYouTube動画データからメタデータ取得・ビュー拡張（Phase 2/3 スクリプト）などを行う場合のみ、YouTube API キーが必要になります。
+## 5. ダッシュボード起動手順
+- **ステータス: 未実装（将来予定）**
+- **詳細**: プロジェクト計画（`docs/PROJECT_OVERVIEW.md`）にある「Webダッシュボード（リアルタイム可視化）」は将来の拡張機能（フェーズ7）であり、現在は起動スクリプト（`app.py` など）や関連するダッシュボード用パッケージは実装されていません。そのため、現時点でダッシュボードを起動する手順はありません。
 
-1. `.env.example` をテンプレートとして参考にしてください。
-2. 実行環境において `YOUTUBE_API_KEY` を環境変数として設定してください。
-3. ※実際に `.env` ファイルが自動でロードされるかどうかは、対象スクリプトや実行環境に依存します。必要に応じて OS 側やシェル側で環境変数を読み込ませてください。
+## 6. バッチ生成手順
+本番データまたは任意の解析データからバッチレポートを生成する手順です。
 
-## 6. ディレクトリ構成
-```text
-video-insight-spec/
-├── docs/             # 仕様書、各フェーズのドキュメント
-├── converter/        # コアロジック（JSON抽出、View生成、レポート出力）
-├── sample_archive/   # 最小実行確認用のダミーJSONデータ
-├── reports/          # 自動生成されたレポートの出力先（実行後に生成）
-├── tests/            # テストコード
-├── requirements.txt      # 実行に必要なパッケージ（最小実行用）
-├── requirements-dev.txt  # 開発・テストに必要なパッケージ
-├── competitor_analytics_generator.py # 競合分析レポート生成エントリポイント
-└── .env.example      # 環境変数のテンプレート（API利用時のみ設定）
-```
-
-## 7. 入力データ仕様
-スクリプトは `--archive-dir` で指定したフォルダ内にある `insight_spec_{lecture_id}.json` を読み込みます。
-
-- **必須構造**: `video_meta`, `knowledge_core`, `views.competitive.snapshot_history` などの階層が必要です（詳細は `docs/specs/JSON_SPEC.md` を参照）。
-- **`sample_archive` の役割**: 初期動作確認のためのモックデータです。実際の分析には実データを `--archive-dir` に配置してください。
-
-## 8. 実行コマンド例
+### 実行方法:
 ```bash
-# サンプルデータでの最小実行
-python competitor_analytics_generator.py --lecture-ids "01,02" --archive-dir "sample_archive"
-
-# 実データでの実行例 (archive ディレクトリに insight_spec_01.json 等が存在する場合)
-python competitor_analytics_generator.py --lecture-ids "01,02,03,04,05" --archive-dir "archive"
+python competitor_analytics_generator.py --lecture-ids "<対象ID(カンマ区切り)>" --archive-dir "<データ格納ディレクトリ>"
 ```
+- **必須引数**:
+  - `--lecture-ids`: 解析対象となるレクチャーID（例: `"01,02"`）。
+  - `--archive-dir`: `insight_spec_{lecture_id}.json` が格納されているディレクトリパス。
 
-## 9. 出力物
-実行後、以下のディレクトリに各種レポートが生成されます。
-- `reports/competitor_analytics/competitor_analytics_YYYYMMDD.json`
-- `reports/html/competitor_analytics_YYYYMMDD.html`
-- `reports/text/competitor_analytics_YYYYMMDD.txt`
+## 7. Executive Summary の位置付け
+- **現状の実態**: `converter/executive_summary_formatter.py` という経営者向けサマリーのジェネレーターコード自体は実装されています。
+- **連携状況**: 現在、主実行経路である `competitor_analytics_generator.py`（および `ReportGenerator`）は、この Executive Summary フォーマッタを呼び出しておらず、**バッチ処理の自動出力パイプラインには未統合**の状態です。
+- **出力されるもの**: バッチ処理で実際に出力されるのは、`reports/html/` および `reports/text/` 配下のフルレポート（HTML/Text）のみとなります。
 
-## 10. よくある失敗
-- **`FileNotFoundError`**: `--archive-dir` の指定忘れ、または指定したディレクトリ内に該当する `insight_spec_*.json` が存在しない。
-- **`UnicodeEncodeError`**: Windows コマンドプロンプト等で実行時、✅ や ❌ の文字が出力できずにクラッシュする（対策: `$env:PYTHONUTF8=1` を付加）。
-- **スキップされる講座がある**: growth_view の生成には最低2回分の履歴（`snapshot_history` >= 2）が必要です。1件しかない場合はスキップされます。
+## 8. 入出力データ
+- **入力データ仕様**:
+  - `--archive-dir` で指定したフォルダ内にある `insight_spec_{lecture_id}.json`。
+  - 内部に `video_meta`（動画基本情報）、`knowledge_core`（テーマ・難易度など）、`views.competitive.snapshot_history`（エンゲージメント推移）が必要です。
+- **出力物**:
+  - `reports/competitor_analytics/competitor_analytics_YYYYMMDD.json`
+  - `reports/html/competitor_analytics_YYYYMMDD.html` (フルHTMLレポート)
+  - `reports/text/competitor_analytics_YYYYMMDD.txt` (Markdown互換テキスト)
 
-## 11. セキュリティ注意
-- **`.env` は絶対に Git にコミットしないでください**（`.gitignore` で除外されています）。
-- 提供された `sample_archive/` には本番の個人情報やAPIキーは含まれていません。実データを扱う際は取り扱いに注意してください。
+## 9. 依存関係
+本リポジトリの依存関係は、本番（runtime）用と開発・テスト（dev）用に分離して定義されています。
 
-## 12. 既知の制約
-- 現在、`competitor_analytics_generator.py` はスクリプト内部で `.env` を直接ロード（`load_dotenv`）していません。API を使用する別のスクリプトを実行する場合は、環境変数がOS側で正しくロードされることを確認してください。
-- レポート生成機能は現在バッチ実行を前提としています。スケジューラ（APScheduler/cron等）の設定は Phase 7-2 以降での実装予定です。
+- **`requirements.txt` (本番実行用)**:
+  - `google-api-python-client` / `google-auth` (将来的なAPI取得/拡張処理用)
+  - `python-dotenv` (環境変数ロード用)
+  - `janome` (NLP / キーワード抽出用として `converter/keyword_extractor.py` が内部使用するため**必須**)
+- **`requirements-dev.txt` (開発・テスト用)**:
+  - `pytest` / `pytest-cov` (単体テスト実行用)
+
+## 10. 既知の制約
+- **`.env` ファイルの自動ロードについて**: 
+  現在、主要なバッチ実行エントリポイントである `competitor_analytics_generator.py` は、内部で `.env` を自動ロード（`load_dotenv`）していません。APIを利用する取得系スクリプト等で `YOUTUBE_API_KEY` を参照させる場合は、OS側やシェル側で環境変数を明示的にロードするか、呼び出し時に環境変数を引き渡す必要があります。
+- **成長推移（Growth View）の生成条件**:
+  入力データ内の `snapshot_history` が2件未満である場合、成長率が計算できないため、Growth View からそのレクチャーは自動的にスキップされます。最小実行の確認時は、`snapshot_history` が2件以上存在する `sample_archive` をご使用ください。

--- a/docs/PROJECT_OVERVIEW.md
+++ b/docs/PROJECT_OVERVIEW.md
@@ -45,8 +45,8 @@ YouTube動画の洞察・競合分析システム。動画視聴データを構�
 実装ファイル：
 - html_formatter.py - レスポンシブCSSを使用したHTML生成
 - text_formatter.py - マークダウン変換
-- executive_summary_formatter.py - 1ページサマリー生成
-- report_generator.py - オーケストレーション
+- executive_summary_formatter.py - 1ページサマリー生成（※現在フォーマッタ自体は実装済みですが、主実行経路の report_generator.py には未統合です）
+- report_generator.py - オーケストレーション（現在は HTML / Text のみ出力）
 
 ## フェーズ5：商品化・営業資料
 
@@ -137,7 +137,7 @@ Year 3予測（シナリオB）：
 - reports/competitor_analytics/ - 生JSON
 - reports/html/ - HTMLレポート
 - reports/text/ - テキスト/マークダウンレポート
-- reports/executive_summary/ - 1ページサマリー
+- reports/executive_summary/ - 1ページサマリー（※フォーマッタの実装は完了していますが、自動出力パイプラインには未統合です）
 - reports/samples/ - PoCサンプルレポート（フェーズ6）
 
 ## ビジネスモデル


### PR DESCRIPTION
## 概要
コードレベルでの実装実態の調査に基づき、`README.md` および `docs/PROJECT_OVERVIEW.md` を現状実装（コード内の事実）に合わせて同期・更新しました。

## 背景
これまでドキュメントや計画書上で言及のあった「Webダッシュボード起動スクリプト (`app.py`)」や「経営者向けサマリー (`Executive Summary`)」の自動統合状態について、実装とのズレがないかをコードベースで一次情報を確認の上、修正を行いました。

## 調査結果（コード内の事実）
1. **Webダッシュボード (`app.py`) について**:
   - 調査の結果、現在リポジトリ内には `app.py` などの起動スクリプトやダッシュボード用の実装コード・パッケージ依存（Streamlitなど）は**一切存在しません**。
   - `docs/PROJECT_OVERVIEW.md` で計画されている通り、Webダッシュボードはフェーズ7（将来予定）の機能であり、現段階では**未実装**であることを明記しました。
2. **Executive Summary について**:
   - `converter/executive_summary_formatter.py` 自体は実装されていますが、主要な実行エントリポイントである `competitor_analytics_generator.py` や `ReportGenerator` はこのフォーマッタを呼び出しておらず、**バッチ自動出力のパイプラインには未統合**であることを明記しました。

## 対応内容
- `README.md` をユーザー推薦の10章構成に沿って再構造化。
- Webダッシュボード（`app.py`）が未実装であること、および主要な起動方法が `competitor_analytics_generator.py` によるバッチレポート生成であることを明確に記載。
- `docs/PROJECT_OVERVIEW.md` の記述も、`executive_summary_formatter.py` が未統合である点や `reports/executive_summary/` ディレクトリが自動出力されない現状に合わせて更新。

## 確認事項
- コアロジックの変更はありません。
- 現行の主要利用経路のみに焦点を当て、開発者が迷う要素（存在しない `app.py` を探す等）を完全に排除しました。
