### PR TITLE
[Refactor] executive_report.json 依存を廃止し insight_spec 直接集計へ移行

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,6 @@ video-insight-spec/
 │   ├── narrative_engine.py           # GPT-4o 言語化エンジン
 │   └── requirements.txt              # ダッシュボード専用の依存関係
 ├── data/                             # 集計済み JSON 等 of 置き場
-│   ├── executive_report.json         # ダッシュボード用サマリーデータ
 │   └── final_statistics_report.json
 ├── competitor_analytics_generator.py # バッチレポート生成メイン
 ├── requirements-dev.txt              # 開発用依存関係

--- a/streamlit_app/analytics_engine.py
+++ b/streamlit_app/analytics_engine.py
@@ -29,17 +29,23 @@ class AnalyticsEngine:
             views_list.append(metadata.get('views', 0))
             likes_list.append(metadata.get('likes', 0))
             comments_list.append(metadata.get('comments', 0))
-            sp_list.append(lec.get('semantic_purity_score', 0))
-            q_list.append(lec.get('quality_score', 0))
-            r_list.append(lec.get('ranking_score', 0))
+            sp = lec.get('semantic_purity_score')
+            if sp is not None: sp_list.append(sp)
+            q = lec.get('quality_score')
+            if q is not None: q_list.append(q)
+            r = lec.get('ranking_score')
+            if r is not None: r_list.append(r)
         
         return {
-            'avg_semantic_purity': round(np.mean(sp_list), 1) if sp_list else 0,
-            'avg_quality': round(np.mean(q_list), 1) if q_list else 0,
-            'avg_ranking': round(np.mean(r_list), 1) if r_list else 0,
+            'avg_semantic_purity': round(np.mean(sp_list), 1) if sp_list else None,
+            'avg_quality': round(np.mean(q_list), 1) if q_list else None,
+            'avg_ranking': round(np.mean(r_list), 1) if r_list else None,
             'total_views': sum(views_list),
             'total_likes': sum(likes_list),
-            'total_comments': sum(comments_list)
+            'total_comments': sum(comments_list),
+            'semantic_purity_count': len(sp_list),
+            'quality_count': len(q_list),
+            'ranking_count': len(r_list)
         }
 
     def get_funnel_stage_analysis(self, lecture_id):

--- a/streamlit_app/app.py
+++ b/streamlit_app/app.py
@@ -35,9 +35,9 @@ with st.spinner("📂 データをロード中..."):
         st.warning(f"⚠️ 分析エンジン初期化エラー: {e}")
         analysis_available = False
 
-if exec_report is None:
-    st.error("❌ データが見つかりません")
-    st.stop()
+if not exec_report or 'lectures' not in exec_report:
+    st.warning("⚠️ 講座データが見つかりません。")
+    # フォールバック処理で必ず生成されるためここは通常通り通過します
 
 # ================================================================
 # モード選択
@@ -58,11 +58,14 @@ if analysis_mode == "チャンネル全体分析":
         st.subheader("KPI メトリクス")
         col1, col2, col3 = st.columns(3)
         with col1:
-            st.metric("平均 Semantic Purity", f"{metrics.get('avg_semantic_purity', 0):.1f}")
+            val = metrics.get('avg_semantic_purity')
+            st.metric("平均 Semantic Purity", f"{val:.1f}" if val is not None else "未算出")
         with col2:
-            st.metric("平均 Quality Score", f"{metrics.get('avg_quality', 0):.1f}")
+            val = metrics.get('avg_quality')
+            st.metric("平均 Quality Score", f"{val:.1f}" if val is not None else "未算出")
         with col3:
-            st.metric("平均 Ranking Score", f"{metrics.get('avg_ranking', 0):.1f}")
+            val = metrics.get('avg_ranking')
+            st.metric("平均 Ranking Score", f"{val:.1f}" if val is not None else "未算出")
         
         st.markdown("---")
         
@@ -102,14 +105,14 @@ if analysis_mode == "チャンネル全体分析":
         lectures_dict = exec_report['lectures']
         ranking = []
         for lec_id, lec in sorted(lectures_dict.items(), 
-                                  key=lambda x: x[1].get('quality_score', 0), 
+                                  key=lambda x: x[1].get('quality_score') or 0, 
                                   reverse=True):
             ranking.append({
                 '順位': len(ranking) + 1,
                 '講座': f"講座{lec_id}",
                 'タイトル': lec.get('title', '')[:35],
-                'Quality': lec.get('quality_score', 0),
-                'Purity': lec.get('semantic_purity_score', 0)
+                'Quality': lec.get('quality_score') if lec.get('quality_score') is not None else "未算出",
+                'Purity': lec.get('semantic_purity_score') if lec.get('semantic_purity_score') is not None else "未算出"
             })
         
         st.dataframe(pd.DataFrame(ranking), use_container_width=True)
@@ -134,9 +137,9 @@ if analysis_mode == "チャンネル全体分析":
         
         | メトリクス | 値 |
         |---|---|
-        | 平均 Semantic Purity | {metrics.get('avg_semantic_purity', 0):.1f} |
-        | 平均 Quality Score | {metrics.get('avg_quality', 0):.1f} |
-        | 平均 Ranking Score | {metrics.get('avg_ranking', 0):.1f} |
+        | 平均 Semantic Purity | {f"{metrics.get('avg_semantic_purity'):.1f}" if metrics.get('avg_semantic_purity') is not None else "未算出"} |
+        | 平均 Quality Score | {f"{metrics.get('avg_quality'):.1f}" if metrics.get('avg_quality') is not None else "未算出"} |
+        | 平均 Ranking Score | {f"{metrics.get('avg_ranking'):.1f}" if metrics.get('avg_ranking') is not None else "未算出"} |
         | 総再生数 | {metrics.get('total_views', 0):,} |
         | 総いいね | {metrics.get('total_likes', 0):,} |
         | 総コメント | {metrics.get('total_comments', 0):,} |
@@ -152,9 +155,9 @@ if analysis_mode == "チャンネル全体分析":
             detail_data.append({
                 '講座': f"講座{lec_id}",
                 'タイトル': lec.get('title', '')[:40],
-                'Semantic Purity': lec.get('semantic_purity_score', 0),
-                'Quality Score': lec.get('quality_score', 0),
-                'Ranking Score': lec.get('ranking_score', 0),
+                'Semantic Purity': lec.get('semantic_purity_score') if lec.get('semantic_purity_score') is not None else "未算出",
+                'Quality Score': lec.get('quality_score') if lec.get('quality_score') is not None else "未算出",
+                'Ranking Score': lec.get('ranking_score') if lec.get('ranking_score') is not None else "未算出",
                 '再生数': metadata.get('views', 0),
                 'いいね': metadata.get('likes', 0),
                 'コメント': metadata.get('comments', 0)
@@ -295,11 +298,14 @@ else:
         if exec_data:
             col1, col2, col3 = st.columns(3)
             with col1:
-                st.metric("Semantic Purity", f"{exec_data.get('semantic_purity_score', 0):.1f}")
+                val = exec_data.get('semantic_purity_score')
+                st.metric("Semantic Purity", f"{val:.1f}" if val is not None else "未算出")
             with col2:
-                st.metric("Quality Score", f"{exec_data.get('quality_score', 0):.1f}")
+                val = exec_data.get('quality_score')
+                st.metric("Quality Score", f"{val:.1f}" if val is not None else "未算出")
             with col3:
-                st.metric("Ranking Score", f"{exec_data.get('ranking_score', 0):.1f}")
+                val = exec_data.get('ranking_score')
+                st.metric("Ranking Score", f"{val:.1f}" if val is not None else "未算出")
             
             st.markdown("---")
             

--- a/streamlit_app/app.py
+++ b/streamlit_app/app.py
@@ -39,6 +39,8 @@ if not exec_report or 'lectures' not in exec_report:
     st.warning("⚠️ 講座データが見つかりません。")
     # フォールバック処理で必ず生成されるためここは通常通り通過します
 
+lectures_dict = exec_report.get('lectures', {}) if exec_report else {}
+
 # ================================================================
 # モード選択
 analysis_mode = st.radio("**分析モード選択:**", 
@@ -102,7 +104,6 @@ if analysis_mode == "チャンネル全体分析":
         st.markdown("---")
         
         st.subheader("講座ランキング（Quality Score）")
-        lectures_dict = exec_report['lectures']
         ranking = []
         for lec_id, lec in sorted(lectures_dict.items(), 
                                   key=lambda x: x[1].get('quality_score') or 0, 
@@ -294,7 +295,7 @@ else:
     with tab1:
         st.subheader("動画品質メトリクス")
         
-        exec_data = exec_report['lectures'].get(f"{lecture_num:02d}")
+        exec_data = lectures_dict.get(f"{lecture_num:02d}")
         if exec_data:
             col1, col2, col3 = st.columns(3)
             with col1:
@@ -336,9 +337,9 @@ else:
                 この講座の基本指標:
                 - 講座ID: {lecture_num:02d}
                 - タイトル: {exec_data.get('title', '')}
-                - Semantic Purity: {exec_data.get('semantic_purity_score', 0):.1f}
-                - Quality Score: {exec_data.get('quality_score', 0):.1f}
-                - Ranking Score: {exec_data.get('ranking_score', 0):.1f}
+                - Semantic Purity: {f"{exec_data.get('semantic_purity_score'):.1f}" if exec_data.get('semantic_purity_score') is not None else "未算出"}
+                - Quality Score: {f"{exec_data.get('quality_score'):.1f}" if exec_data.get('quality_score') is not None else "未算出"}
+                - Ranking Score: {f"{exec_data.get('ranking_score'):.1f}" if exec_data.get('ranking_score') is not None else "未算出"}
                 - 再生数: {metadata.get('views', 0):,}
                 - いいね: {metadata.get('likes', 0):,} (1000再生あたり {engagement_metrics.get('likes_per_1000_views', 0):.2f})
                 - コメント: {metadata.get('comments', 0):,} (1000再生あたり {engagement_metrics.get('comments_per_1000_views', 0):.2f})

--- a/streamlit_app/data_loader.py
+++ b/streamlit_app/data_loader.py
@@ -107,6 +107,9 @@ def transform_executive_report(exec_report):
         }
         records.append(record)
     
+    if not records:
+        return pd.DataFrame(columns=["講座ID", "タイトル", "セマンティック純度スコア", "品質スコア", "ランキングスコア", "ビュー数", "いいね数", "コメント数"])
+    
     df = pd.DataFrame(records)
     df["講座番号"] = df["講座ID"].str.extract(r'(\d+)').astype(int)
     df = df.sort_values("講座番号").drop("講座番号", axis=1)

--- a/streamlit_app/data_loader.py
+++ b/streamlit_app/data_loader.py
@@ -9,17 +9,52 @@ from config import DATA_DIR, EXEC_REPORT_PATH, SCORE_LEVELS
 
 @st.cache_resource
 def load_executive_report():
-    """Executive Report JSON をロード"""
+    """Executive Report JSON をロード（無ければ insight_spec から生成）"""
     try:
         with open(EXEC_REPORT_PATH, 'r', encoding='utf-8') as f:
             data = json.load(f)
         return data
-    except FileNotFoundError:
-        st.error(f"❌ ファイル不見つかり: {EXEC_REPORT_PATH}")
-        return None
-    except json.JSONDecodeError as e:
-        st.error(f"❌ JSON デコードエラー: {e}")
-        return None
+    except (FileNotFoundError, json.JSONDecodeError):
+        # フォールバック: insight_spec をロードして動的生成する
+        insight_specs = load_insight_specs()
+        return build_executive_report_from_specs(insight_specs)
+
+def build_executive_report_from_specs(insight_specs):
+    """insight_specs からダッシュボード表示用の View-Model を動的に生成する"""
+    lectures = {}
+    for lecture_id, spec in insight_specs.items():
+        # video_meta
+        video_meta = spec.get("video_meta", {})
+        title = video_meta.get("title", "")
+        
+        # calculate semantic purity
+        center_pins = spec.get("knowledge_core", {}).get("center_pins", [])
+        purity_scores = [pin.get("base_purity_score", 0) for pin in center_pins if isinstance(pin.get("base_purity_score"), (int, float))]
+        semantic_purity_score = round(sum(purity_scores) / len(purity_scores), 2) if purity_scores else None
+        
+        # quality & ranking are not in insight_spec
+        quality_score = None
+        ranking_score = None
+        
+        # views metrics
+        metrics = spec.get("views", {}).get("metrics", {})
+        views = metrics.get("view_count", 0)
+        likes = metrics.get("like_count", 0)
+        comments = metrics.get("comment_count", 0)
+        
+        lectures[lecture_id] = {
+            "title": title,
+            "semantic_purity_score": semantic_purity_score,
+            "quality_score": quality_score,
+            "ranking_score": ranking_score,
+            "metadata": {
+                "views": views,
+                "likes": likes,
+                "comments": comments
+            }
+        }
+    
+    return {"lectures": lectures}
 
 @st.cache_resource
 def load_insight_specs():
@@ -63,9 +98,9 @@ def transform_executive_report(exec_report):
         record = {
             "講座ID": f"講座{lecture_id}",
             "タイトル": data.get("title", ""),
-            "セマンティック純度スコア": data.get("semantic_purity_score", 0),
-            "品質スコア": data.get("quality_score", 0),
-            "ランキングスコア": data.get("ranking_score", 0),
+            "セマンティック純度スコア": data.get("semantic_purity_score", None),
+            "品質スコア": data.get("quality_score", None),
+            "ランキングスコア": data.get("ranking_score", None),
             "ビュー数": data.get("metadata", {}).get("views", 0),
             "いいね数": data.get("metadata", {}).get("likes", 0),
             "コメント数": data.get("metadata", {}).get("comments", 0)
@@ -113,14 +148,21 @@ def create_theme_dataframe(theme_counts):
 
 def calculate_aggregate_metrics(df_exec):
     """集計メトリクスを計算"""
+    purity_series = pd.to_numeric(df_exec["セマンティック純度スコア"], errors='coerce').dropna()
+    quality_series = pd.to_numeric(df_exec["品質スコア"], errors='coerce').dropna()
+    ranking_series = pd.to_numeric(df_exec["ランキングスコア"], errors='coerce').dropna()
+    
     return {
         "講座数": len(df_exec),
         "総ビュー数": int(df_exec["ビュー数"].sum()),
         "総いいね数": int(df_exec["いいね数"].sum()),
         "総コメント数": int(df_exec["コメント数"].sum()),
-        "平均セマンティック純度": round(df_exec["セマンティック純度スコア"].mean(), 2),
-        "平均品質スコア": round(df_exec["品質スコア"].mean(), 2),
-        "平均ランキングスコア": round(df_exec["ランキングスコア"].mean(), 2)
+        "平均セマンティック純度": round(purity_series.mean(), 2) if not purity_series.empty else None,
+        "平均品質スコア": round(quality_series.mean(), 2) if not quality_series.empty else None,
+        "平均ランキングスコア": round(ranking_series.mean(), 2) if not ranking_series.empty else None,
+        "セマンティック純度_算出件数": len(purity_series),
+        "品質スコア_算出件数": len(quality_series),
+        "ランキングスコア_算出件数": len(ranking_series),
     }
 
 def get_score_level(score):

--- a/streamlit_app/narrative_engine.py
+++ b/streamlit_app/narrative_engine.py
@@ -49,8 +49,8 @@ class NarrativeEngine:
     def explain_channel_overview(self, metrics):
         """チャンネル全体の解説"""
         prompt = f"""このYouTubeチャンネルの分析結果:
-- 平均Quality Score: {metrics.get('avg_quality', 0):.1f}
-- 平均Semantic Purity: {metrics.get('avg_semantic_purity', 0):.1f}
+- 平均Quality Score: {f"{metrics.get('avg_quality'):.1f}" if metrics.get('avg_quality') is not None else "未算出"}
+- 平均Semantic Purity: {f"{metrics.get('avg_semantic_purity'):.1f}" if metrics.get('avg_semantic_purity') is not None else "未算出"}
 - 総再生数: {metrics.get('total_views', 0):,}
 - 総いいね: {metrics.get('total_likes', 0):,}
 - 総コメント: {metrics.get('total_comments', 0):,}


### PR DESCRIPTION
## 目的
Streamlit ダッシュボード起動における executive_report.json の強依存を廃止し、正規の納品データである insight_spec_*.json を直接集計して起動できるようにする設計変更です。

## 変更点
- data_loader.py: load_executive_report() を改修し、ファイルが無い場合は insight_spec_*.json から集計辞書を動的生成するようにしました。
- app.py / analytics_engine.py / narrative_engine.py: quality_score や ranking_score など、insight_spec に存在しない指標を None として保持し、UIで「未算出」等として正しく処理・表示するように修正しました。また、欠損がある場合は平均の母数からも除外しています。
- README.md: executive_report.json 依存に関する記述を削除し、設計思想を同期しました。

## 動作確認
- executive_report.json を削除した状態で正常起動することを確認
- OPENAI_API_KEY 未設定でも劣化運転で正常動作することを確認