### PR TITLE
[Fix] ダッシュボードのデモ用メトリクス表示を是正し GPT 実動作を検証

### DIFF
--- a/streamlit_app/data_loader.py
+++ b/streamlit_app/data_loader.py
@@ -37,7 +37,7 @@ def build_executive_report_from_specs(insight_specs):
         ranking_score = None
         
         # views metrics
-        metrics = spec.get("views", {}).get("metrics", {})
+        metrics = spec.get("views", {}).get("competitive", {}).get("metrics", {})
         views = metrics.get("view_count", 0)
         likes = metrics.get("like_count", 0)
         comments = metrics.get("comment_count", 0)


### PR DESCRIPTION
## 目的
ダッシュボード上の未表示数値を本来の実データに補正し、GPTの実動作検証を行うことでデモ品質を向上させる修正です。

## 修正内容
- data_loader.py: \iews.competitive.metrics\ へのパス補正

## 確認結果
- \quality_score\ と \anking_score\ が欠落している状況でのGPTの実APIによる生応答を確認済
